### PR TITLE
Add unique index to prevent duplicated friendships

### DIFF
--- a/db/migrate/1_create_friendships.rb
+++ b/db/migrate/1_create_friendships.rb
@@ -13,6 +13,7 @@ CreateFriendships.class_eval do
 
       t.timestamps
     end
+     add_index :friendable_id, :friend_id, unique: true
   end
 
   def self.down


### PR DESCRIPTION
Add unique index between friendable_id and friend_id to prevent duplicated friendships.